### PR TITLE
fix homepage URLs (`xmake`  to `xmake-io`)

### DIFF
--- a/gradle-xmake-plugin/build.gradle
+++ b/gradle-xmake-plugin/build.gradle
@@ -34,8 +34,8 @@ gradlePlugin {
 }
 
 pluginBundle {
-    website = 'https://github.com/xmake/xmake-gradle'
-    vcsUrl = 'https://github.com/xmake/xmake-gradle'
+    website = 'https://github.com/xmake-io/xmake-gradle'
+    vcsUrl = 'https://github.com/xmake-io/xmake-gradle'
     description = 'A gradle plugin that integrates xmake seamlessly'
     tags = ['xmake', 'c++', 'lua']
 


### PR DESCRIPTION
A small fix so I hope it's okay if I just make a quick PR!

I noticed that the URL is wrong on the Gradle plugin homepage 

https://plugins.gradle.org/plugin/org.tboox.gradle-xmake-plugin

![image](https://user-images.githubusercontent.com/897017/135653778-b4045b7d-86e3-4516-8cef-1bdd65f974ca.png)


![image](https://user-images.githubusercontent.com/897017/135653879-87d9c8ba-1a26-44fe-bc85-d484b32f18c0.png)

I noticed that the URLs in `gradle-xmake-plugin/build.gradle` used this same, 404, URL, so I updated the URLs to be https://github.com/xmake-io/xmake-gradle. 