### PR TITLE
[fix] please update xmake to >= 2.9.6 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,31 +1,43 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion "30.0.2"
+    namespace 'org.tboox.xmake.app'  // Update the namespace accordingly
+    compileSdkVersion 34  // Updated SDK version
     defaultConfig {
         applicationId "org.tboox.xmake"
-        minSdkVersion 15
-        targetSdkVersion 29
+        minSdkVersion 21  // Updated minimum SDK version
+        targetSdkVersion 34  // Updated target SDK version
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
-
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    buildToolsVersion "34.0.0"  // Ensure build tools match the compile SDK
+}
+
+tasks.withType(JavaCompile).configureEach {
+    javaCompiler = javaToolchains.compilerFor {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'androidx.appcompat:appcompat:1.0.2'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
+    implementation 'androidx.appcompat:appcompat:1.6.1'            // Updated version
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'  // Updated version
+    testImplementation 'junit:junit:4.13.2'                         // Updated version
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'       // Updated version
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'  // Updated version
     implementation project(path: ':nativelib')
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.tboox.xmake" >
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"
@@ -8,11 +7,12 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme" >
-        <activity android:name=".MainActivity" >
+        android:theme="@style/AppTheme">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>

--- a/app/src/main/java/org/tboox/xmake/MainActivity.java
+++ b/app/src/main/java/org/tboox/xmake/MainActivity.java
@@ -1,20 +1,20 @@
 package org.tboox.xmake;
 
-import androidx.appcompat.app.AppCompatActivity;
 import android.os.Bundle;
+import androidx.appcompat.app.AppCompatActivity;
 import android.widget.TextView;
+
+import org.tboox.xmake.app.R;
 import org.tboox.xmake.nativelib.Test;
 
-
 public class MainActivity extends AppCompatActivity {
-
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
+        setContentView(R.layout.activity_main);  // Ensure this matches the layout file name
         String content = Test.loadTests();
         if (content != null) {
-            TextView textView = (TextView) findViewById(R.id.content);
+            TextView textView = findViewById(R.id.content);
             textView.setText(content);
         }
     }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,20 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".MainActivity">
+    android:layout_height="match_parent">
 
     <TextView
         android:id="@+id/content"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Hello World!"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
-</androidx.constraintlayout.widget.ConstraintLayout>
+        android:text="TextView" />
+</RelativeLayout>

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:4.0.0"
+        classpath 'com.android.tools.build:gradle:8.7.3'  // Updated version
         //classpath fileTree(dir: 'gradle-xmake-plugin/build/libs', include: ['*.jar'])
 
         // NOTE: Do not place your application dependencies here; they belong
@@ -20,6 +20,12 @@ allprojects {
         google()
         mavenCentral()
 
+    }
+
+    tasks.withType(JavaCompile).configureEach {
+        javaCompiler = javaToolchains.compilerFor {
+            languageVersion = JavaLanguageVersion.of(17)
+        }
     }
 }
 

--- a/gradle-xmake-plugin/build.gradle
+++ b/gradle-xmake-plugin/build.gradle
@@ -38,5 +38,10 @@ gradlePlugin {
     }
 }
 
-sourceCompatibility = "8"
-targetCompatibility = "8"
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+    toolchain {
+        // languageVersion = JavaLanguageVersion.of(17)
+    }
+}

--- a/gradle-xmake-plugin/build.gradle
+++ b/gradle-xmake-plugin/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     // to publish the plugin at the gradle plugin portal
-    id "com.gradle.plugin-publish" version "0.11.0"
+    id "com.gradle.plugin-publish" version "1.1.0"  // Updated version
     // Apply the java-library plugin to add support for Java Library
     id 'java-gradle-plugin'
     id 'maven-publish'
@@ -29,20 +29,11 @@ gradlePlugin {
         xmakePlugin {
             id = 'org.tboox.gradle-xmake-plugin'
             implementationClass = 'org.tboox.gradle.XMakePlugin'
-        }
-    }
-}
-
-pluginBundle {
-    website = 'https://github.com/xmake-io/xmake-gradle'
-    vcsUrl = 'https://github.com/xmake-io/xmake-gradle'
-    description = 'A gradle plugin that integrates xmake seamlessly'
-    tags = ['xmake', 'c++', 'lua']
-
-    plugins {
-        xmakePlugin {
-            // id is captured from java-gradle-plugin configuration
             displayName = 'Gradle XMake plugin'
+            description = 'A gradle plugin that integrates xmake seamlessly'
+            tags = ['xmake', 'c++', 'lua']
+            website = 'https://github.com/xmake-io/xmake-gradle'
+            vcsUrl = 'https://github.com/xmake-io/xmake-gradle'
         }
     }
 }

--- a/gradle-xmake-plugin/src/main/resources/lua/install_artifacts.lua
+++ b/gradle-xmake-plugin/src/main/resources/lua/install_artifacts.lua
@@ -41,7 +41,7 @@ end
 function _install_artifacts(targets, opt)
     local arch = opt.arch
     local installdir = opt.installdir
-    -- assert(xmake.version():satisfies(">= 2.9.6"), "please update xmake to >= 2.9.6")
+    assert(xmake.version():ge("2.9.6"), "please update xmake to >= 2.9.6")
     for _, target in ipairs(targets) do
         install(target, {installdir = installdir, libdir = arch})
     end
@@ -149,7 +149,7 @@ end
 function _clean_artifacts(targets, opt)
     local arch = opt.arch
     local installdir = opt.installdir
-    -- assert(xmake.version():satisfies(">= 2.9.6"), "please update xmake to >= 2.9.6")
+    assert(xmake.version():ge("2.9.6"), "please update xmake to >= 2.9.6")
     for _, target in ipairs(targets) do
         uninstall(target, {installdir = installdir, libdir = arch})
     end

--- a/gradle-xmake-plugin/src/main/resources/lua/install_artifacts.lua
+++ b/gradle-xmake-plugin/src/main/resources/lua/install_artifacts.lua
@@ -41,7 +41,7 @@ end
 function _install_artifacts(targets, opt)
     local arch = opt.arch
     local installdir = opt.installdir
-    assert(xmake.version():satisfies(">= 2.9.6"), "please update xmake to >= 2.9.6")
+    -- assert(xmake.version():satisfies(">= 2.9.6"), "please update xmake to >= 2.9.6")
     for _, target in ipairs(targets) do
         install(target, {installdir = installdir, libdir = arch})
     end
@@ -149,7 +149,7 @@ end
 function _clean_artifacts(targets, opt)
     local arch = opt.arch
     local installdir = opt.installdir
-    assert(xmake.version():satisfies(">= 2.9.6"), "please update xmake to >= 2.9.6")
+    -- assert(xmake.version():satisfies(">= 2.9.6"), "please update xmake to >= 2.9.6")
     for _, target in ipairs(targets) do
         uninstall(target, {installdir = installdir, libdir = arch})
     end

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,3 +23,5 @@ android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
 android.enableJetifier=true
 
+# R.* and Manifest.* annotations are not final and can be changed at runtime
+android.nonFinalResIds=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,6 @@
-#Sun Apr 12 10:14:05 CST 2020
+#Fri Dec 20 09:58:35 CST 2024
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-#distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+zipStoreBase=GRADLE_USER_HOME

--- a/nativelib/build.gradle
+++ b/nativelib/build.gradle
@@ -5,15 +5,19 @@ apply plugin: 'com.android.library'
 //apply plugin: "org.tboox.gradle-xmake-plugin"
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion "30.0.2"
+    namespace 'org.tboox.xmake.nativelib'  // Update the namespace accordingly
+    compileSdkVersion 34  // Updated SDK version
 
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    buildToolsVersion "34.0.0"  // Ensure build tools match the compile SDK
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 29
-        versionCode 1
-        versionName "1.0"
+        minSdkVersion 21  // Updated minimum SDK version
+        targetSdkVersion 34  // Updated target SDK version
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'consumer-rules.pro'
@@ -75,11 +79,17 @@ android {
     }
 }
 
+tasks.withType(JavaCompile).configureEach {
+    javaCompiler = javaToolchains.compilerFor {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
     implementation 'androidx.appcompat:appcompat:1.0.2'
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
+    testImplementation 'junit:junit:4.13.2'  // Updated version
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'  // Updated version
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'  // Updated version
 }

--- a/nativelib/src/main/AndroidManifest.xml
+++ b/nativelib/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.tboox.xmake.nativelib" />
+     />

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,2 @@
-include ':app', ':nativelib', ':gradle-xmake-plugin'
+include ':gradle-xmake-plugin'
 rootProject.name='xmake-gradle'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,3 @@
-include ':gradle-xmake-plugin'
+// include ':gradle-xmake-plugin' ':app', ':nativelib',
+include   ':gradle-xmake-plugin' , ':app', ':nativelib'
 rootProject.name='xmake-gradle'


### PR DESCRIPTION
[The issue related](https://github.com/xmake-io/xmake-gradle/issues/21#issue-2752051762)

When I try to make a PR, the building give a lot's errors.

After a lot of retry and modification, the plugin can be build on my ubuntu 24.10 with openjdk 17.

The main changes include the followings:
1.  Openjdk 17 build ok
2.  AGP upgraded to 8.7.3
3.  Fixed errors of [app] and [nativelib] when building
4.  Commented the lines in install_artifacts.lua which cause the error


I'm not sure my modification is OK for others,  just wish this can help others.

I'll use the plugin with my private version anyway.

Thanks for your great works!
